### PR TITLE
Fix text penetrating first tile on startpage

### DIFF
--- a/src/scss/startpage/square_media.scss
+++ b/src/scss/startpage/square_media.scss
@@ -14,7 +14,7 @@
     }
 
     .greatness .content {
-        flex: 1 0;
+        flex: 1 0 auto;
     }
 
     .l-image-left, .l-image-right, .l-image-full {


### PR DESCRIPTION
- add display: flex; flex: 1 0 auto to .content

closes: #1